### PR TITLE
Make api.gocd.org index page mobile friendly

### DIFF
--- a/templates/api.go.cd.index.html.erb
+++ b/templates/api.go.cd.index.html.erb
@@ -28,6 +28,7 @@
 		ga('send', 'pageview');
   </script>
   <meta charset="UTF-8"><meta http-equiv="refresh" content="6;url=/current/">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 </head>
 <body>
 
@@ -35,6 +36,10 @@
 <style>
   .paragraph {
     font-size: 20px;
+  }
+
+  #links a {
+      display: block;
   }
 </style>
 
@@ -45,7 +50,7 @@
   <br>
 </p>
 
-<p class="paragraph">
+<p class="paragraph" id="links">
   <% versions.each do |version_data| -%>
     <% if version_data[:type] == 'latest' -%>
       <a href="current"><%= version_data[:version] %> (current)</a><br>


### PR DESCRIPTION
Redoing: https://github.com/gocd/api.go.cd/commit/1dbc0f3542c53d95a4ff585c752150682f57e3bd

@ketan This is the reason my change made in https://github.com/gocd/api.go.cd/commit/1dbc0f3542c53d95a4ff585c752150682f57e3bd was overridden in https://github.com/gocd/api.go.cd/commit/e6904f2840c30b3d47a6c5e9226a146b01737240.

@bdpiparva @kritika-singh3  Maybe we should remove https://github.com/gocd/api.go.cd/blob/master/lib/root.html.erb? My preference would be to have it in the api.gocd.org repo, but at least it should be in one place.