### PR TITLE
Make developer docs list page mobile friendly

### DIFF
--- a/templates/developer.go.cd.index.html.erb
+++ b/templates/developer.go.cd.index.html.erb
@@ -26,9 +26,13 @@
 
 <h1>Welcome to Go Continuous Delivery Developer Documentation</h1>
 <style>
-  .paragraph {
-    font-size: 20px;
-  }
+ .paragraph {
+     font-size: 20px;
+ }
+
+ #links a {
+     display: block;
+ }
 </style>
 
 <p class="paragraph">
@@ -38,7 +42,7 @@
   <br>
 </p>
 
-<p class="paragraph">
+<p class="paragraph" id="links">
   <% versions.each do |version_data| -%>
     <% if version_data[:type] == 'latest' -%>
       <a href="current"><%= version_data[:version] %> (current)</a><br>


### PR DESCRIPTION
Before:

<img width="1156" alt="2019_09_20_18-26-07" src="https://user-images.githubusercontent.com/172235/65362100-2c0b5280-dbd4-11e9-9b37-6ab6480bb0a9.png">

After:

<img width="1141" alt="2019_09_20_18-25-18" src="https://user-images.githubusercontent.com/172235/65362104-30377000-dbd4-11e9-94ef-fcc9c6fedb01.png">

The "Page loading issues" warning is because google analytics is blocked on my machine.